### PR TITLE
fix fluent-bit lua configuration

### DIFF
--- a/integrations/fluent-bit/kubernetes/fluent-bit-coralogix-cm.yaml
+++ b/integrations/fluent-bit/kubernetes/fluent-bit-coralogix-cm.yaml
@@ -30,12 +30,6 @@ data:
         Match               kube.*
         K8S-Logging.Exclude On
     
-    [FILTER]
-        Name    lua
-        Match   *
-        script  /fluent-bit/etc/functions.lua
-        call    dedot
-
     [OUTPUT]
         Name          coralogix
         Match         kube.*


### PR DESCRIPTION
If you currently run this integration, you will get:
```
[2022/06/07 11:14:29] [error] [filter:lua:lua.1] cannot access script '/fluent-bit/etc/functions.lua'
[2022/06/07 11:14:29] [error] [filter_lua] filter cannot be loaded
[2022/06/07 11:14:29] [error] Failed initialize filter lua.1
[2022/06/07 11:14:29] [error] [lib] backend failed
```

I used [dive](https://github.com/wagoodman/dive) to explore the image `fluent/fluent-bit:latest`  and the lua script is not there:

![image](https://user-images.githubusercontent.com/22289110/172371992-97693e9e-f542-46d3-829f-5d6a4716109c.png)

Another way to fix it is to add the script, but I'm not sure if we need it? 