### PR TITLE
feat: fluent-bit plugin: send high resolution timestamp

### DIFF
--- a/integrations/fluent-bit/plugin/out_coralogix_test.go
+++ b/integrations/fluent-bit/plugin/out_coralogix_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+const SECOND_IN_NS = 1_000_000_000
+
+func randomTime() time.Time {
+  rand.Seed(time.Now().UnixNano())
+  timeFrom := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
+  timeTo := time.Now().UnixNano()
+  timeDiff := timeTo - timeFrom
+  timeRand := rand.Int63n(timeDiff) + timeFrom
+  seconds, nanoseconds := timeRand / SECOND_IN_NS, timeRand % SECOND_IN_NS
+
+  return time.Unix(seconds, nanoseconds)
+}
+
+func BenchmarkParseTimestamp(b *testing.B) {
+  for i := 0; i < b.N; i++ {
+    parseTimestamp(randomTime().Format(time.RFC3339Nano))
+  }
+}


### PR DESCRIPTION
At our company we need this plugin to be able to send higher resolution timestamps to Coralogix (including nanoseconds).
At the moment this plugin uses the following code to generate the timestamp:
```
"timestamp": timestamp / 1000000 
```
(this is the line: https://github.com/coralogix/integrations-docs/blob/master/integrations/fluent-bit/plugin/out_coralogix.go#L144)

This division turns nano seconds timestamp into milliseconds. For example:
```
1663861860886123456 / 1000000 = 1663861860886
```
Since the Coralogix API supports nanosecond precision in the `timestamp` field. We can include nanoseconds after the floating point. For example:
```
"timestamp": 1663861860886.123456
```
This PR does exactly this using the Golang `math/big` standard lib to make high precision division and preserve nanoseconds in the timestamp.

Looking forward to someone checking this PR. Let me know if we need to change/fix something.

High res timestamps are quite important for us, as they will make it easier for us to understand the order of events in Coralogix app.