### PR TITLE
Fix Terraform integration for logs from GCS

### DIFF
--- a/integrations/gcp/gcs/terraform/variables.tf
+++ b/integrations/gcp/gcs/terraform/variables.tf
@@ -1,19 +1,25 @@
 variable "private_key" {
   description = "Coralogix Private Key"
-  type        = "string"
+  type        = string
 }
 
 variable "app_name" {
   description = "Application name"
-  type        = "string"
+  type        = string
 }
 
 variable "sub_name" {
   description = "Subsystem name"
-  type        = "string"
+  type        = string
 }
 
 variable "bucket_name" {
   description = "The name of the storage bucket to watch"
-  type        = "string"
+  type        = string
+}
+
+variable "function_bucket_name" {
+  description = "The name of the bucket where the Cloud Function will be stored. Defaults to `bucket_name` for compatibility reason."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
* Modernize the variable definitions: type must not be quoted anymore since 0.15 https://github.com/hashicorp/terraform/blob/v0.15/CHANGELOG.md#0150-april-14-2021

* Allow to upload the Cloud Function to a different bucket than the bucket the function watches for new logs. They don't have to be in the same place, and it's probably a good idea overall not to mix code and logs.